### PR TITLE
Ajout accolade fermeture namespace fv2d

### DIFF
--- a/StatesHydro.h
+++ b/StatesHydro.h
@@ -119,3 +119,4 @@ State computeFlux(State &q, const Params &params) {
 
   return fout;
 }
+}


### PR DESCRIPTION
Une accolade manquait dans le fichier StatesHydro.h, l'espace de nommage fv2d ne se fermait pas et cassait tout.